### PR TITLE
Mg fix cluster attributes

### DIFF
--- a/synthea-on-databricks.py
+++ b/synthea-on-databricks.py
@@ -59,7 +59,7 @@ node_type_id
 # DBTITLE 1,Dashboard Widget Configuration
 dbutils.widgets.text("catalog_name", "")
 dbutils.widgets.text("schema_name", "synthea")
-dbutils.widgets.text("instance_pool_id", "", "Optional Instance Pool ID for the Cluster Spec")
+# dbutils.widgets.text("instance_pool_id", "", "Optional Instance Pool ID for the Cluster Spec")
 dbutils.widgets.text("number_of_job_runs", "1", "Number of times to run the job")
 dbutils.widgets.dropdown("create_landing_zone", "true", ["true", "false"], "Optional Create a landing zone")
 dbutils.widgets.dropdown("inject_bad_data", "true", ["true", "false"], "Optional injection of bad data to select files")
@@ -78,7 +78,7 @@ dbutils.widgets.dropdown("run_job", "true", ["true", "false"], "Optional Run the
 # DBTITLE 1,Retrieve Widget Inputs
 catalog_name = dbutils.widgets.get("catalog_name")
 schema_name = dbutils.widgets.get("schema_name")
-instance_pool_id = dbutils.widgets.get("instance_pool_id")
+# instance_pool_id = dbutils.widgets.get("instance_pool_id")
 number_of_job_runs = int(dbutils.widgets.get("number_of_job_runs"))
 create_landing_zone = dbutils.widgets.get("create_landing_zone").lower()
 inject_bad_data = dbutils.widgets.get("inject_bad_data").lower()
@@ -106,7 +106,6 @@ If create_landing_zone == True, the Databricks workflow created by this notebook
 Please note that is the catalog, schema, or Volume do not exist, the workflow notebooks will attempt to create them.  If the user does not have the appropriate permissions to create or use the inputted catalog, or create or use the inputted schema, the workflow will fail during execution.  Please adjust the inputted values and re-run this notebook. 
 
 Cluster Specification Details: 
-instance_pool_id = {instance_pool_id}
 node_type_id = {node_type_id}
 
 Number of times the Databricks workflow will be executed to simulate variability in patient record creation: number_of_job_runs = {number_of_job_runs}
@@ -123,7 +122,7 @@ post_job_result = dbutils.notebook.run(
     "catalog_name": catalog_name
     ,"schema_name": schema_name
     ,"create_landing_zone": create_landing_zone
-    ,"instance_pool_id": instance_pool_id
+    # ,"instance_pool_id": instance_pool_id
     ,"node_type_id": node_type_id
     ,"inject_bad_data": inject_bad_data
     ,"min_records": min_records

--- a/workflows/synthea-on-dbx-create-workflow.py
+++ b/workflows/synthea-on-dbx-create-workflow.py
@@ -235,29 +235,29 @@ if serverless == "true":
 else:
   cluster_spec = JobCluster.from_dict(cluster_spec_dict)
   # if instance_pool_id == "": 
-    cluster_spec = JobCluster(
-      job_cluster_key = job_cluster_key
-      ,new_cluster = ClusterSpec(
-        spark_version = latest_lts_version
-        ,spark_conf = {
-          "spark.master": "local[*, 4]",
-          "spark.databricks.cluster.profile": "singleNode"
-        }
-        ,custom_tags = {
-          "ResourceClass": "SingleNode"
-        }
-        ,spark_env_vars = {
-          "JNAME": "zulu17-ca-amd64"
-        }
-        ,data_security_mode = DataSecurityMode("SINGLE_USER")
-        ,runtime_engine = RuntimeEngine("STANDARD")
-        ,num_workers = 0
-        ,node_type_id = node_type_id
-        ,aws_attributes = AwsAttributes(
-          availability = AwsAvailability("ON_DEMAND")
-        )
-      )
-    )
+    # cluster_spec = JobCluster(
+    #   job_cluster_key = job_cluster_key
+    #   ,new_cluster = ClusterSpec(
+    #     spark_version = latest_lts_version
+    #     ,spark_conf = {
+    #       "spark.master": "local[*, 4]",
+    #       "spark.databricks.cluster.profile": "singleNode"
+    #     }
+    #     ,custom_tags = {
+    #       "ResourceClass": "SingleNode"
+    #     }
+    #     ,spark_env_vars = {
+    #       "JNAME": "zulu17-ca-amd64"
+    #     }
+    #     ,data_security_mode = DataSecurityMode("SINGLE_USER")
+    #     ,runtime_engine = RuntimeEngine("STANDARD")
+    #     ,num_workers = 0
+    #     ,node_type_id = node_type_id
+    #     ,aws_attributes = AwsAttributes(
+    #       availability = AwsAvailability("ON_DEMAND")
+    #     )
+    #   )
+    # )
   # else:
   #   cluster_spec = JobCluster(
   #     job_cluster_key = job_cluster_key

--- a/workflows/synthea-on-dbx-create-workflow.py
+++ b/workflows/synthea-on-dbx-create-workflow.py
@@ -17,9 +17,9 @@ dbutils.library.restartPython()
 # DBTITLE 1,Set Databricks Widgets
 dbutils.widgets.text("catalog_name", "")
 dbutils.widgets.text("schema_name", "synthea")
-dbutils.widgets.text(
-    "instance_pool_id", "", "Optional Instance Pool ID for the Cluster Spec"
-)
+# dbutils.widgets.text(
+#     "instance_pool_id", "", "Optional Instance Pool ID for the Cluster Spec"
+# )
 dbutils.widgets.text(
     "node_type_id",
     "i3.xlarge",
@@ -48,7 +48,7 @@ dbutils.widgets.text(name = "max_records", defaultValue="1000", label = "Maximum
 # DBTITLE 1,Get Widget Inputs
 catalog_name = dbutils.widgets.get("catalog_name")
 schema_name = dbutils.widgets.get("schema_name")
-instance_pool_id = dbutils.widgets.get("instance_pool_id")
+# instance_pool_id = dbutils.widgets.get("instance_pool_id")
 node_type_id = dbutils.widgets.get("node_type_id")
 create_landing_zone = dbutils.widgets.get("create_landing_zone").lower()
 inject_bad_data = dbutils.widgets.get("inject_bad_data").lower()
@@ -126,7 +126,6 @@ Job cluster key: {job_cluster_key}
 Job description: {job_description}
 
 Cluster Specification Details: 
-instance_pool_id = {instance_pool_id}
 node_type_id = {node_type_id}
 
 Note that node_type_id will only be used if an instance_pool_id is not set.


### PR DESCRIPTION
Updated cluster attributes to force on demand for AWS and Azure.  Previously deployments on Azure would fail due to the setting of AWS attributes.  Now each cloud has a different cluster spec created for the job.  GCP will default to spot as GCP attributes were not set as part of this new cluster spec.  